### PR TITLE
NixOS integration changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,3 +28,6 @@ Alternatively, if you wish to keep the OAuth2 client secret in a seperate file::
 
    oauth2_introspection_endpoint = <introspection url with no secret/password>
    oauth2_introspection_endpoint_secret = <path to file containing secret>
+
+Introspection URL may also contain the path to a Unix domain socket for local
+deployments: ``http+unix://radicale@%2Frun%2F<service>%2Fgunicorn.sock/<path>``

--- a/README.rst
+++ b/README.rst
@@ -20,3 +20,11 @@ Here is a configuration example::
    type = radicale_modoboa_auth_oauth2
 
    oauth2_introspection_endpoint = <introspection url>
+
+Alternatively, if you wish to keep the OAuth2 client secret in a seperate file::
+
+   [auth]
+   type = radicale_modoboa_auth_oauth2
+
+   oauth2_introspection_endpoint = <introspection url with no secret/password>
+   oauth2_introspection_endpoint_secret = <path to file containing secret>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Radicale
 requests
+requests-unixsocket


### PR DESCRIPTION
Each commit is basically self-explanatory:

 * First commit is just about not logging secrets
 * Second commit allows reading from a separate file
    *  This is needed on NixOS since the Radicale configuration file is managed by the NixOS derivation, but we don’t have a the secret at that point yet (and also putting it in the derivation makes it world-readable in the Nix store)
 * Third commit allows connecting to Modoboa using the Gunicorn Unix domain socket, improving the Radicale sandbox and making the internal connection more reliable
    * Unfortunately `requests-unixsocket` disallows reading authentication data from the URL’s userinfo part (https://github.com/msabramo/requests-unixsocket/issues/88), so the authentication data is instead passed using the `auth=` keyword (which is also the recommended way by `requests` documentation)